### PR TITLE
[Goliath] Display translation keys duplicates in the translation key

### DIFF
--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -263,7 +263,12 @@ class ImportTranslationsCommand extends ContainerAwareCommand
 
         foreach ($finder as $file) {
             $this->output->write(sprintf('Importing <comment>"%s"</comment> ... ', $file->getPathname()));
-            $number = $importer->import($file, $this->input->getOption('force'), $this->input->getOption('merge'));
+            $forceUpdate = $this->input->getOption('force');
+            list($domain, $locale, $extention) = explode('.', $file->getFilename());
+            if(strpos($domain, 'messages+intl-icu') === 0) {
+                $forceUpdate = true;
+            }
+            $number = $importer->import($file, $forceUpdate, $this->input->getOption('merge'));
             $this->output->writeln(sprintf('%d translations', $number));
 
             $skipped = $importer->getSkippedKeys();

--- a/Command/ImportTranslationsCommand.php
+++ b/Command/ImportTranslationsCommand.php
@@ -263,12 +263,7 @@ class ImportTranslationsCommand extends ContainerAwareCommand
 
         foreach ($finder as $file) {
             $this->output->write(sprintf('Importing <comment>"%s"</comment> ... ', $file->getPathname()));
-            $forceUpdate = $this->input->getOption('force');
-            list($domain, $locale, $extention) = explode('.', $file->getFilename());
-            if(strpos($domain, 'messages+intl-icu') === 0) {
-                $forceUpdate = true;
-            }
-            $number = $importer->import($file, $forceUpdate, $this->input->getOption('merge'));
+            $number = $importer->import($file, $this->input->getOption('force'), $this->input->getOption('merge'));
             $this->output->writeln(sprintf('%d translations', $number));
 
             $skipped = $importer->getSkippedKeys();

--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -98,9 +98,6 @@ class FileImporter
         if (!isset($this->loaders[$extention])) {
             throw new \RuntimeException(sprintf('No load found for "%s" format.', $extention));
         }
-        if(strpos($domain, 'messages+intl-icu') === 0) {
-            $domain = 'messages';
-        }
 
         $messageCatalogue = $this->loaders[$extention]->load($file->getPathname(), $locale, $domain);
 
@@ -126,7 +123,16 @@ class FileImporter
                 $transUnit = $this->transUnitManager->create($key, $domain);
             }
 
+            if(strpos($domain, 'messages+intl-icu') === 0) {
+                $transUnitToUpdate = $this->storage->getTransUnitByKeyAndDomain($key, 'messages');
+                $transUnitToDelete = $this->storage->getTransUnitByKeyAndDomain($key, 'messages+intl-icu');
+                if ($transUnitToDelete) {
+                    $translation = $this->transUnitManager->deleteTranslation($transUnitToDelete, $locale);
+                }
+                $translation = $this->transUnitManager->updateTranslation($transUnitToUpdate, $locale, $content);
+            } else {
                 $translation = $this->transUnitManager->addTranslation($transUnit, $locale, $content, $translationFile);
+            }
                 if ($translation instanceof TranslationInterface) {
                     $imported++;
                 } else if($forceUpdate) {

--- a/Translation/Importer/FileImporter.php
+++ b/Translation/Importer/FileImporter.php
@@ -98,6 +98,9 @@ class FileImporter
         if (!isset($this->loaders[$extention])) {
             throw new \RuntimeException(sprintf('No load found for "%s" format.', $extention));
         }
+        if(strpos($domain, 'messages+intl-icu') === 0) {
+            $domain = 'messages';
+        }
 
         $messageCatalogue = $this->loaders[$extention]->load($file->getPathname(), $locale, $domain);
 


### PR DESCRIPTION
When the updated translations file **messages+intl-icu.en_GB.yml** is used in the translation tool and we run the app/console lexik:translations:import command we can see that in the translation tool UI we have duplicate values for the same translation key (old and updated one) as can be seen in the screenshot bellow:
![MicrosoftTeams-image (2)](https://github.com/lexik/LexikTranslationBundle/assets/134720833/bc50549f-5a3c-48c5-994f-6ae8284ce6a6)
It's because the translation file has the **s+intl-icu** suffix compared to the old file name and is treated as a new file in the translation tool DB

For the import commande, each file is identified by the triplet: domain, locale, extention
for exemple:
     - messages.fr_FR.yml
domain: messages
locale: fr_FR
extention: yml
    - messages+intl-icu.fr_FR.yml
domain: messages+intl-icu
locale: fr_FR
extention: yml
as a consequence the translation for the two files is imported twice
![AttachFileHandler (1)](https://github.com/lexik/LexikTranslationBundle/assets/134720833/0654f23b-d270-47c8-8739-259af7487043)
if we delete the keys andnupdate the domaines for both files, in order to have the same domain for both of them, the import command will create one translation key, but the old one (first i serted in the DB) is the one saved as a translation for the key
![AttachFileHandler (2)](https://github.com/lexik/LexikTranslationBundle/assets/134720833/07099ab7-f420-4a8b-ae46-e32834ae8463)

**what to do:**

1.  update the commande to delete all keys in the case of **messages+intl-icu** files
2. if there is more then one file identified by same locale ans prefexed by messages, force the update (import file parameter $forceUpdate=true)
3. Make messages and messagesxxxx have same domaine (messages)

**what is left to do:**
**update the commande to delete all keys in the case of **messages+intl-icu** files**
